### PR TITLE
nvhpc/20.7 does not like having break in sequential acc loops

### DIFF
--- a/solutions/openacc/nbody.cpp
+++ b/solutions/openacc/nbody.cpp
@@ -43,16 +43,14 @@ void boundary_conditions(double* x)
         dsize = L[2*j+1] - L[2*j];
         do {
           xv += dsize;
-          if (xv > L[2*j]) break;
-        } while(true);
+        } while( xv <= L[2*j]);
         x[3*i+j] = xv;
       }
       else if (xv > L[2*j+1]) {
         dsize = L[2*j+1] - L[2*j];
         do {
           xv -= dsize;
-          if (xv < L[2*j+1]) break;
-        } while(true);
+        } while(xv >= L[2*j+1]);
         x[3*i+j] = xv;
       }
     }


### PR DESCRIPTION
This is to fix 
```
pgc++ -O3 -fast -std=c++11 -Minfo=accel -ta:tesla:managed  -o nbody nbody.cpp -lm
"nbody.cpp", line 46: error: branching into or out of a parallel region is not
          allowed
            if (xv > L[2*j]) break;
                             ^

"nbody.cpp", line 54: error: branching into or out of a parallel region is not
          allowed
            if (xv < L[2*j+1]) break;
                               ^

2 errors detected in the compilation of "nbody.cpp".
make: *** [Makefile:14: nbody] Error 2
``` 

which happens otherwise with `nvhpc/20.7` 